### PR TITLE
ci: switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -171,13 +171,15 @@ jobs:
         if: steps.bump.outputs.bump != 'none'
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
 
+      # Auth via npm trusted publishing (OIDC) — no NPM_TOKEN. Requires this
+      # repo + workflow to be configured as a trusted publisher on npmjs.com,
+      # and npm >= 11.5.1 (node 22 bundles npm 10, hence the upgrade).
       - name: Publish to npm
         if: steps.bump.outputs.bump != 'none'
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm install -g npm@latest
+          npm publish --provenance --access public
 
       - name: File docs issue
         if: steps.bump.outputs.bump != 'none'


### PR DESCRIPTION
## Why

v0.4.0's npm publish failed with `EOTP`: the `NPM_TOKEN` granular token was created without 2FA bypass, so every write demands an interactive authenticator code CI can't provide. It also expires **2026-07-07** under npm's 90-day granular-token cap — so even a fixed token means quarterly rotation.

## What

Switch to [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) — tokenless, no expiry, nothing to rotate or leak:

- Drop `NODE_AUTH_TOKEN` / `registry-url` from the publish steps (a leftover `${NODE_AUTH_TOKEN}` reference in `.npmrc` with the env unset would make npm error).
- Upgrade npm before publishing — OIDC needs npm ≥ 11.5.1; node 22 bundles npm 10.
- `permissions: id-token: write` was already set; `--provenance` unchanged.

## ⚠️ Merge order

**Do not merge until the trusted publisher is configured on npmjs.com** (only the org owner can): npmjs.com → `@openaccountant/wilson` → Settings → Trusted publisher → GitHub Actions → owner `openaccountant`, repo `wilson`, workflow `release-on-merge.yml`, environment blank. Merging before that makes the next release's publish step fail (auth error instead of EOTP).

After it's configured and this merges, the old `NPM_TOKEN` secret and the expiring npm token can both be deleted.

Note: `ci:` commits don't trigger a version bump, so merging this PR alone won't cut a release.