### PR TITLE
ci: push release commits with a release-bot app token

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -14,10 +14,19 @@ jobs:
     # Skip release commits to prevent infinite loops
     if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
     steps:
+      # The default GITHUB_TOKEN cannot bypass the main-branch ruleset, so the
+      # release commit/tag are pushed with a token minted for the release-bot
+      # GitHub App, which is on the ruleset's bypass list.
+      - uses: actions/create-github-app-token@v2
+        id: release-bot
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.release-bot.outputs.token }}
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
Final piece of the release-pipeline fix (after #27's npm OIDC switch).

## Why

The release workflow pushes its `chore(release)` version-bump commit to `main` with `GITHUB_TOKEN`, which cannot bypass the branch ruleset — GitHub doesn't offer its own Actions app as a ruleset bypass actor (confirmed in both API and UI), and org policy disables deploy keys. This is what killed v0.4.0's publish run at the "Commit release" step.

## What

Mint a short-lived installation token for a dedicated **release-bot GitHub App** via `actions/create-github-app-token`, and check out / push with it. The app goes on the ruleset's bypass list, where GitHub Apps *are* supported.

Bonus: unlike `GITHUB_TOKEN`, app-token pushes trigger workflows, so CI runs on release commits too (the `chore(release):` guard still prevents release recursion).

## ⚠️ Merge order — requires one-time setup first (org owner)

1. **Create the app**: <https://github.com/organizations/openaccountant/settings/apps/new> — name `wilson-release-bot`, any homepage URL, **uncheck Webhook → Active**, Repository permissions → **Contents: Read and write**, "Only on this account" → Create.
2. On the app page: note the **App ID**; generate a **private key** (downloads a .pem).
3. **Install it**: left sidebar → Install App → openaccountant → Only select repositories → `wilson`.
4. **Bypass list**: repo Settings → Rules → "main protection" → Add bypass → `wilson-release-bot` (appears once installed) → Save.
5. **Secrets** (repo Settings → Secrets and variables → Actions): `RELEASE_APP_ID` = the App ID, `RELEASE_APP_PRIVATE_KEY` = full contents of the .pem.

Merging before setup makes the next release fail at token minting (no worse than today's failure mode).