### PR TITLE
fix: restore installable wilson bin under npm 11

### DIFF
--- a/bin/wilson.js
+++ b/bin/wilson.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env bun
+// npm strips non-JS bin entries at publish (npm 11 rejects .tsx), so this
+// shim is the installable entrypoint. Bun executes the TypeScript directly.
+import "../src/index.tsx";

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Open Accountant - Privacy-first AI bookkeeper CLI",
   "repository": {
     "type": "git",
-    "url": "https://github.com/openaccountant/wilson.git"
+    "url": "git+https://github.com/openaccountant/wilson.git"
   },
   "type": "module",
   "main": "src/index.tsx",
   "bin": {
-    "wilson": "./src/index.tsx"
+    "wilson": "./bin/wilson.js"
   },
   "scripts": {
     "start": "bun run src/index.tsx",


### PR DESCRIPTION
Found in the v0.4.1 release run's publish log:

```
npm warn publish "bin[wilson]" script name src/index.tsx was invalid and removed
```

npm 11 (now installed as `npm@latest` in the release workflow) rejects `.tsx` bin entries and **silently strips them at publish** — meaning `npm i -g @openaccountant/wilson` would install no `wilson` command at all.

## Fix

- `bin/wilson.js`: two-line `#!/usr/bin/env bun` shim importing `src/index.tsx` (Bun runs the TS directly; the CLI already requires Bun for `bun:sqlite`).
- `bin.wilson` → `./bin/wilson.js`.
- Normalize `repository.url` to `git+https://…` (the other publish warning).

## Testing

- `./bin/wilson.js --help` prints the CLI usage (exit 0).
- `npm pack --dry-run` includes `bin/wilson.js` and no longer warns.
- `bun run typecheck` passes.