### PR TITLE
fix: drop ./ prefix from bin path so npm 11 keeps it

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "main": "src/index.tsx",
   "bin": {
-    "wilson": "./bin/wilson.js"
+    "wilson": "bin/wilson.js"
   },
   "scripts": {
     "start": "bun run src/index.tsx",


### PR DESCRIPTION
Follow-up to #29 — the v0.4.2 publish *still* stripped the bin. Root cause isn't the file extension: **npm 11 rejects `./`-prefixed bin paths**. `npm pkg fix` under npm 11.18 rewrites `"./bin/wilson.js"` → `"bin/wilson.js"`, and with that change `npm publish --dry-run` is completely warning-free with `bin/wilson.js` in the tarball (reproduced and verified locally against a clone of main).

One-character diff; the #29 shim itself stays.